### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 version=1.4.2-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19

--- a/src/main/java/io/kestra/plugin/weaviate/BatchCreate.java
+++ b/src/main/java/io/kestra/plugin/weaviate/BatchCreate.java
@@ -1,8 +1,7 @@
 package io.kestra.plugin.weaviate;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,6 +11,7 @@ import java.util.stream.Collectors;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.VoidOutput;
@@ -33,7 +33,6 @@ import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 import static io.kestra.core.utils.Rethrow.throwFunction;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -127,13 +126,9 @@ public class BatchCreate extends WeaviateConnection implements RunnableTask<Void
                 ).toList();
         } else if (objects instanceof String uri) {
             try (
-                BufferedReader reader = new BufferedReader(
-                    new InputStreamReader(
-                        runContext.storage().getFile(URI.create(runContext.render(uri)))
-                    )
-                )
+                InputStream is = runContext.storage().getFile(URI.create(runContext.render(uri)))
             ) {
-                weaviateObjects = FileSerde.readAll(reader, Map.class)
+                weaviateObjects = FileSerde.readAll(is, Map.class)
                     .map(
                         throwFunction(
                             map -> WeaviateObject.builder()

--- a/src/main/java/io/kestra/plugin/weaviate/Query.java
+++ b/src/main/java/io/kestra/plugin/weaviate/Query.java
@@ -1,9 +1,9 @@
 package io.kestra.plugin.weaviate;
 
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -167,15 +167,10 @@ public class Query extends WeaviateConnection implements RunnableTask<FetchOutpu
 
     private URI store(List<Object> data, RunContext runContext) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
-        try (
-            BufferedWriter fileWriter = new BufferedWriter(new FileWriter(tempFile));
-            var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
-        ) {
-
+        try (OutputStream output = new FileOutputStream(tempFile)) {
             var flux = Flux.fromIterable(data);
             FileSerde.writeAll(output, flux).block();
-
-            fileWriter.flush();
+            output.flush();
         }
 
         return runContext.storage().putFile(tempFile);

--- a/src/test/java/io/kestra/plugin/weaviate/WeaviateTest.java
+++ b/src/test/java/io/kestra/plugin/weaviate/WeaviateTest.java
@@ -1,8 +1,6 @@
 package io.kestra.plugin.weaviate;
 
-import java.io.BufferedReader;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
 
@@ -30,8 +28,8 @@ public abstract class WeaviateTest {
     }
 
     protected List<Map> readObjectsFromStream(InputStream inputStream) throws Exception {
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
-            return FileSerde.readAll(reader, Map.class).collectList().block();
+        try (inputStream) {
+            return FileSerde.readAll(inputStream, Map.class).collectList().block();
         }
     }
 }


### PR DESCRIPTION
Migrate deprecated Reader/Writer-based FileSerde API to InputStream/OutputStream for binary ION compatibility (kestra/kestra#3155).